### PR TITLE
Include the test in the CPAN dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cpan/ChangeLog
 cpan/extra
 cpan/README.md
 cpan/README
+cpan/t

--- a/cpan/Makefile
+++ b/cpan/Makefile
@@ -13,7 +13,7 @@ TARBALL = \
 
 all: $(TARBALL)
 
-EXTRA: ChangeLog README.md
+EXTRA: ChangeLog README.md t/00-markdown.t t/files/README.md.in
 
 ChangeLog:
 	cp ../ChangeLog $@
@@ -32,7 +32,9 @@ UNIT_TESTS =
 
 EXTRA = \
     ChangeLog \
-    README.md
+    README.md \
+    t/00-markdown.t \
+    t/files/README.md.in
 
 extra:
 	rm -f $@
@@ -40,7 +42,7 @@ extra:
 	  echo $$a >> $@; \
 	done
 
-$(TARBALL): $(PERL_MODULES) $(PERL_SCRIPTS) ChangeLog README.md extra
+$(TARBALL): $(PERL_MODULES) $(PERL_SCRIPTS) $(EXTRA) extra
 	 make-cpan-dist \
 	   -e bin \
 	   -f extra \
@@ -54,6 +56,14 @@ $(TARBALL): $(PERL_MODULES) $(PERL_SCRIPTS) ChangeLog README.md extra
 
 README.md: ../README.md.in
 	../md-utils.pl  $< > $@ || rm -f $@
+
+t/files/README.md.in: ../README.md.in
+	test -d t/files || mkdir -p t/files
+	cp $< $@
+
+t/00-markdown.t: ../t/00-markdown.t
+	test -d t || mkdir -p t
+	cp $< $@
 
 install: $(TARBALL)
 	cpanm -v -l $$HOME  $<

--- a/t/00-markdown.t
+++ b/t/00-markdown.t
@@ -3,18 +3,34 @@
 use strict;
 use warnings;
 
-use lib qw{.};
+use lib qw{$Bin/..};
+use FindBin qw($Bin);
 
 use Data::Dumper;
 use English qw{-no_match_vars};
 use Test::More;
-use Bedrock::Test::Utils qw(:all);
 
-our %TESTS = fetch_test_descriptions(*DATA);  # from Test::Utils
+our %TESTS = (
+    new             => 'Markdown::Render->new',
+    render_markdown => 'render HTML from markdown file',
+);
 
 ########################################################################
 
 plan tests => 1 + keys %TESTS;
+
+# Find the test input file.
+my $test_file;
+for ('files', '..') {
+    my $file = "$Bin/$_/README.md.in";
+    if (-f $file) {
+        $test_file = $file;
+        last;
+    }
+}
+
+BAIL_OUT("Unable to find test file")
+    unless defined $test_file;
 
 use_ok('Markdown::Render');
 
@@ -23,7 +39,7 @@ subtest 'new' => sub {
 ########################################################################
   my $md = eval {
     Markdown::Render->new(
-      infile => 'README.md.in',
+      infile => $test_file,
       engine => 'text_markdown',
     );
   };
@@ -40,7 +56,7 @@ subtest 'render_markdown' => sub {
 ########################################################################
   my $md = eval {
     Markdown::Render->new(
-      infile => 'README.md.in',
+      infile => $test_file,
       engine => 'text_markdown',
     );
   };
@@ -67,6 +83,4 @@ subtest 'render_markdown' => sub {
 1;
 
 __DATA__
-new => Markdown::Render->new
-render_markdown => render HTML from markdown file
-END_OF_PLAN  
+END_OF_PLAN


### PR DESCRIPTION
Hey Rob,

I've packaged Markdown::Render for inclusion into Debian. To allow the use of the test file, this PR removes the dependency on Bedrock::Test::Utils as the use of it looks to be rather straight forward.

I haven't tested it with your make-cpan-dist, but eyeballing the bash script, it looks to me like it should work okay.

Cheers,
Andrew